### PR TITLE
Optimize resources requested for METAEUK process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Common Changelog](https://common-changelog.org)
 
 - Publish log files to output directory. ([#9](https://github.com/metagenlab/zshoman/pull/9)) (Niklaus Johner)
 - Avoid rerunning processes leading to output already present in the output directory. ([#10](https://github.com/metagenlab/zshoman/pull/10)) (Niklaus Johner)
+- Optimize resources requested for METAEUK process. ([#11](https://github.com/metagenlab/zshoman/pull/11)) (Niklaus Johner)
 
 ### Added
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -104,7 +104,8 @@ process {
         ext.args = '-i 95'
     }
     withName: METAEUK_EASYPREDICT {
-        memory = { 200.GB * task.attempt }
+        memory = { 150.GB * task.attempt }
+        cpus   = { 16     * task.attempt }
     }
     withName: MOTUS_PROFILE {
         ext.args = '-c -k mOTU -q -p'


### PR DESCRIPTION
METAEUK seems to use exactly 136GB of RAM when running, probably the size of the database in memory. So we set the memory limit to 150GB. We also increase the number of CPUs used to 16, as it parallelizes well and as we typically cannot run many processes at the same time using 150GB of RAM anyway, so this makes better use of our resources.