### PR TITLE
Fix pipeline for samples lacking any eukaryotic contigs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Common Changelog](https://common-changelog.org)
 ### Fixed
 
 - Fix pipeline for running only per sample analyses. ([#9](https://github.com/metagenlab/zshoman/pull/9)) (Niklaus Johner)
+- Fix pipeline for samples lacking any eukaryotic contigs. ([#18](https://github.com/metagenlab/zshoman/pull/18)) (Niklaus Johner)
 
 ### Changed
 

--- a/main.nf
+++ b/main.nf
@@ -239,7 +239,12 @@ workflow {
         assembly_stats = ASSEMBLY_STATS(filtered_assembly)
 
         prokaryotic_genes = PRODIGAL(FILTER_SCAFFOLDS.out.prok_scaffolds, "gff")
-        eukaryotic_genes = METAEUK_EASYPREDICT(FILTER_SCAFFOLDS.out.euk_scaffolds, params.metaeuk_db)
+        // We only predict eukaryotic genes if there are any (i.e. file is not empty)
+        // this channel will therefore not contain all the samples, but it's fine
+        // as we mix it back with the prokaryotic_genes channel afterwards.
+        eukaryotic_genes = METAEUK_EASYPREDICT(
+            FILTER_SCAFFOLDS.out.euk_scaffolds.filter({ it[1].size() > 0}),
+            params.metaeuk_db)
 
         // we need to compress the output from MetaEuk so that both eukaryotic
         // and prokaryotic genes are compressed


### PR DESCRIPTION
MetaEuk fails when the input file is empty, we therefore need to filter the channel for non-empty files before running the process. This leads to the `eukaryotic_genes` channel not containing all the samples, but it does not require any further changes because:
- For the gene catalog we collect all prokariotic and eukariotic genes together for further analysis, so a missing sample in one channel does not matter
- For individual sample analysis, we mix the  `eukaryotic_genes` and  `prokaryotic_genes` channels together and then group them by sample, getting a list of files containing the genes for each sample. The files from the list are then concatenated together in the `CAT_AA` and `CAT_NT` processes, so that we should again all the genes for each sample in one file. So that is fine as well. 