### PR TITLE
Add expected size to groupTuple operators in pipeline. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Changed
 
+- Avoid waiting for all samples before starting gene counts and functional annotations. ([#23](https://github.com/metagenlab/zshoman/pull/23)) (Niklaus Johner)
 - Enable nf-boost cleanup and make the default error strategy to ignore. ([#21](https://github.com/metagenlab/zshoman/pull/21)) (Niklaus Johner)
 - Publish log files to output directory. ([#9](https://github.com/metagenlab/zshoman/pull/9)) (Niklaus Johner)
 - Avoid rerunning processes leading to output already present in the output directory. ([#10](https://github.com/metagenlab/zshoman/pull/10), [#13](https://github.com/metagenlab/zshoman/pull/13)) (Niklaus Johner)

--- a/main.nf
+++ b/main.nf
@@ -288,7 +288,7 @@ workflow {
             /////////////////////////////////////
 
             // We first gather the prokaryotic genes and eukaryotic genes together
-            nt_tuples = prokaryotic_genes.nucleotide_fasta.mix(eukaryotic_genes_nt).groupTuple()
+            nt_tuples = prokaryotic_genes.nucleotide_fasta.mix(eukaryotic_genes_nt).groupTuple(size: 2, remainder: true)
             // Avoid redoing the mapping and count calculation if it was already done
             nt_tuples = nt_tuples.filter({
                 (!params.resume_from_output) || Files.notExists(Paths.get(outdir_abs, it[0].id, "gene_counts"))
@@ -307,7 +307,7 @@ workflow {
             ///////////////////////////////////
 
             // We first gather the prokaryotic genes and eukaryotic genes together
-            aa_tuples = prokaryotic_genes.amino_acid_fasta.mix(eukaryotic_genes_aa).groupTuple()
+            aa_tuples = prokaryotic_genes.amino_acid_fasta.mix(eukaryotic_genes_aa).groupTuple(size: 2, remainder: true)
             // Avoid redoing the annotations if it was already done
             aa_tuples = aa_tuples.filter({
                 (!params.resume_from_output) || Files.notExists(Paths.get(outdir_abs, it[0].id, "annotations"))


### PR DESCRIPTION
This avoids having to wait for all samples before emitting the tuples. Instead it will emit tuples as soon as they are of size two, allowing the workflow to to finish single samples one after the other...