### PR TITLE
Add support for per sample runs in annotations post-processing script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ to [Common Changelog](https://common-changelog.org)
 
 - Add script to merge mOTUS outputs into a single table. ([#20](https://github.com/metagenlab/zshoman/pull/20)) (Niklaus Johner)
 - Add script to filter out already processed samples from input. ([#19](https://github.com/metagenlab/zshoman/pull/19)) (Niklaus Johner)
+- Add support for per sample runs in annotations post-processing script. ([#24](https://github.com/metagenlab/zshoman/pull/24)) (Niklaus Johner)
 - Add option *resume_from_output* to avoid using output directory to skip processes. ([#16](https://github.com/metagenlab/zshoman/pull/16)) (Niklaus Johner)
 - Add support for multi-lane samples. ([#15](https://github.com/metagenlab/zshoman/pull/15)) (Niklaus Johner)
 - Add various scripts for cleaning up the work and output directories. ([#14](https://github.com/metagenlab/zshoman/pull/14), [#19](https://github.com/metagenlab/zshoman/pull/19), [#22](https://github.com/metagenlab/zshoman/pull/22)) (Niklaus Johner)


### PR DESCRIPTION
We update the post-processing script transforming the eggnog output into something usable to also support per sample runs of the pipeline (i.e. no gene catalog). The script is pretty slow, taking several seconds per sample. This could maybe be optimized, but seems unnecessary right now.