### PR TITLE
Change name of output files from bbmerge to simplify downstream usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Changed
 
+- Change name of output files from bbmerge to simplify downstream usage. ([#45](https://github.com/metagenlab/zshoman/pull/45)) (Niklaus Johner)
 - Avoid I/O bottleneck when restarting from output to calculate the gene catalog. ([#43](https://github.com/metagenlab/zshoman/pull/43)) (Niklaus Johner)
 - Avoid redoing contig classification and gene calling when already done. ([#41](https://github.com/metagenlab/zshoman/pull/41)) (Niklaus Johner)
 - Support samples with more than 5 lanes/experiments. ([#40](https://github.com/metagenlab/zshoman/pull/40)) (Farid Chaabane, Niklaus Johner)

--- a/main.nf
+++ b/main.nf
@@ -117,7 +117,7 @@ workflow {
     paired_end_reads_merged = BBMAP_MERGE_PAIRS(hf_reads_split.paired, false)
 
     // prepare a single channel preprocessed_samples with elements of the form
-    // (meta, [*_1_unmerged.fastq.gz, *_2_unmerged.fastq.gz, *_merged.fastq.gz, "*.fastq.gz"])
+    // (meta, [*_unmerged_1.fastq.gz, *_unmerged_2.fastq.gz, *_merged.fastq.gz, "*.fastq.gz"])
     // for paired-end and (meta, *.fastq.gz) for single-end samples
     paired_end_reads = hf_singletons.map({ new Tuple (it[0] + [single_end:false], it[1]) })
     paired_end_reads = paired_end_reads.join(paired_end_reads_merged.merged.join(paired_end_reads_merged.unmerged))
@@ -134,8 +134,8 @@ workflow {
                 ):
             new Tuple (
                 it[0],
-                [Paths.get(outdir_abs, it[0].id, "preprocessed_reads", "${it[0].id}_1_unmerged.fastq.gz"),
-                 Paths.get(outdir_abs, it[0].id, "preprocessed_reads", "${it[0].id}_2_unmerged.fastq.gz"),
+                [Paths.get(outdir_abs, it[0].id, "preprocessed_reads", "${it[0].id}_unmerged_1.fastq.gz"),
+                 Paths.get(outdir_abs, it[0].id, "preprocessed_reads", "${it[0].id}_unmerged_2.fastq.gz"),
                  Paths.get(outdir_abs, it[0].id, "preprocessed_reads", "${it[0].id}_merged.fastq.gz"),
                  Paths.get(outdir_abs, it[0].id, "preprocessed_reads", "${it[0].id}_host_filtered_singletons.fastq.gz")]
                 )

--- a/modules.json
+++ b/modules.json
@@ -1,123 +1,124 @@
 {
-  "name": "",
-  "homePage": "",
-  "repos": {
-    "https://github.com/nf-core/modules.git": {
-      "modules": {
-        "nf-core": {
-          "bbmap/align": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ],
-            "patch": "modules/nf-core/bbmap/align/bbmap-align.diff"
-          },
-          "bbmap/bbduk": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ],
-            "patch": "modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff"
-          },
-          "bbmap/bbmerge": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "bbmap/index": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "bwa/index": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "bwa/mem": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ],
-            "patch": "modules/nf-core/bwa/mem/bwa-mem.diff"
-          },
-          "cat/cat": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "cat/fastq": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "eggnogmapper": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "metaeuk/easypredict": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ],
-            "patch": "modules/nf-core/metaeuk/easypredict/metaeuk-easypredict.diff"
-          },
-          "mmseqs/easycluster": {
-            "branch": "master",
-            "git_sha": "38697a933bef7041bb935c9b8374d9948ce6c794",
-            "installed_by": [
-              "modules"
-            ],
-            "patch": "modules/nf-core/mmseqs/easycluster/mmseqs-easycluster.diff"
-          },
-          "pigz/compress": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "prodigal": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "seqtk/subseq": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ]
-          },
-          "spades": {
-            "branch": "master",
-            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-            "installed_by": [
-              "modules"
-            ],
-            "patch": "modules/nf-core/spades/spades.diff"
-          }
+    "name": "",
+    "homePage": "",
+    "repos": {
+        "https://github.com/nf-core/modules.git": {
+            "modules": {
+                "nf-core": {
+                    "bbmap/align": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/bbmap/align/bbmap-align.diff"
+                    },
+                    "bbmap/bbduk": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff"
+                    },
+                    "bbmap/bbmerge": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/bbmap/bbmerge/bbmap-bbmerge.diff"
+                    },
+                    "bbmap/index": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "bwa/index": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "bwa/mem": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/bwa/mem/bwa-mem.diff"
+                    },
+                    "cat/cat": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "cat/fastq": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "eggnogmapper": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "metaeuk/easypredict": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/metaeuk/easypredict/metaeuk-easypredict.diff"
+                    },
+                    "mmseqs/easycluster": {
+                        "branch": "master",
+                        "git_sha": "38697a933bef7041bb935c9b8374d9948ce6c794",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/mmseqs/easycluster/mmseqs-easycluster.diff"
+                    },
+                    "pigz/compress": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "prodigal": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "seqtk/subseq": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
+                    },
+                    "spades": {
+                        "branch": "master",
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/spades/spades.diff"
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/modules/nf-core/bbmap/bbmerge/bbmap-bbmerge.diff
+++ b/modules/nf-core/bbmap/bbmerge/bbmap-bbmerge.diff
@@ -1,0 +1,39 @@
+Changes in module 'nf-core/bbmap/bbmerge'
+--- modules/nf-core/bbmap/bbmerge/main.nf
++++ modules/nf-core/bbmap/bbmerge/main.nf
+@@ -12,7 +12,7 @@
+ 
+     output:
+     tuple val(meta), path("*_merged.fastq.gz")  , emit: merged
+-    tuple val(meta), path("*_unmerged.fastq.gz"), emit: unmerged
++    tuple val(meta), path("*_unmerged*.fastq.gz"), emit: unmerged
+     tuple val(meta), path("*_ihist.txt")        , emit: ihist
+     path  "versions.yml"                        , emit: versions
+     path  "*.log"                               , emit: log
+@@ -24,7 +24,7 @@
+     def args = task.ext.args ?: ''
+     def prefix = task.ext.prefix ?: "${meta.id}"
+     def in_reads = ( interleave ) ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
+-    def out_reads = ( interleave ) ? "out=${prefix}_merged.fastq.gz outu=${prefix}_unmerged.fastq.gz" : "out=${prefix}_merged.fastq.gz outu1=${prefix}_1_unmerged.fastq.gz outu2=${prefix}_2_unmerged.fastq.gz"
++    def out_reads = ( interleave ) ? "out=${prefix}_merged.fastq.gz outu=${prefix}_unmerged.fastq.gz" : "out=${prefix}_merged.fastq.gz outu1=${prefix}_unmerged_1.fastq.gz outu2=${prefix}_unmerged_2.fastq.gz"
+ 
+     """
+     maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')
+
+--- modules/nf-core/bbmap/bbmerge/meta.yml
++++ modules/nf-core/bbmap/bbmerge/meta.yml
+@@ -46,10 +46,10 @@
+           description: |
+             Groovy Map containing sample information
+             e.g. `[ id:'sample1', single_end:false ]`
+-      - "*_unmerged.fastq.gz":
++      - "*_unmerged*.fastq.gz":
+           type: file
+           description: unmerged reads
+-          pattern: "*_unmerged.fastq"
++          pattern: "*_unmerged*.fastq"
+   - ihist:
+       - meta:
+           type: map
+
+************************************************************

--- a/modules/nf-core/bbmap/bbmerge/main.nf
+++ b/modules/nf-core/bbmap/bbmerge/main.nf
@@ -12,7 +12,7 @@ process BBMAP_BBMERGE {
 
     output:
     tuple val(meta), path("*_merged.fastq.gz")  , emit: merged
-    tuple val(meta), path("*_unmerged.fastq.gz"), emit: unmerged
+    tuple val(meta), path("*_unmerged*.fastq.gz"), emit: unmerged
     tuple val(meta), path("*_ihist.txt")        , emit: ihist
     path  "versions.yml"                        , emit: versions
     path  "*.log"                               , emit: log
@@ -24,7 +24,7 @@ process BBMAP_BBMERGE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def in_reads = ( interleave ) ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
-    def out_reads = ( interleave ) ? "out=${prefix}_merged.fastq.gz outu=${prefix}_unmerged.fastq.gz" : "out=${prefix}_merged.fastq.gz outu1=${prefix}_1_unmerged.fastq.gz outu2=${prefix}_2_unmerged.fastq.gz"
+    def out_reads = ( interleave ) ? "out=${prefix}_merged.fastq.gz outu=${prefix}_unmerged.fastq.gz" : "out=${prefix}_merged.fastq.gz outu1=${prefix}_unmerged_1.fastq.gz outu2=${prefix}_unmerged_2.fastq.gz"
 
     """
     maxmem=\$(echo \"$task.memory\"| sed 's/ GB/g/g')

--- a/modules/nf-core/bbmap/bbmerge/meta.yml
+++ b/modules/nf-core/bbmap/bbmerge/meta.yml
@@ -46,10 +46,10 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*_unmerged.fastq.gz":
+      - "*_unmerged*.fastq.gz":
           type: file
           description: unmerged reads
-          pattern: "*_unmerged.fastq"
+          pattern: "*_unmerged*.fastq"
   - ihist:
       - meta:
           type: map


### PR DESCRIPTION
For the unmerged reads, the extension was 1_unmerged.fastq.gz and 2_unmerged.fastq.gz which is non-standard. We now instead use unmerged_1.fastq.gz and unmerged_2.fastq.gz.

Note that if you have run an older version of zshoman and want to switch to a version including this change, you will have to rename the files in your output folder:

```
rename 's/_1_unmerged\.fastq\.gz/_unmerged_1\.fastq\.gz/g' output/*/postprocessed_reads/* 
rename 's/_2_unmerged_2\.fastq\.gz/_unmerged_2\.fastq\.gz/g' output/*/postprocessed_reads/* 
```