### PR TITLE
Add FASTQC to pipeline for raw and preprocessed reads

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -135,26 +135,21 @@ process {
              enabled: params.publish.logs]
         ]
     }
+    withName: 'FASTQC_*' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/fastqc" },
+            mode: params.publish_dir_mode,
+            pattern: '{*.html,*.zip}'
+        ]
+    }
     withName: FASTQC_RAW {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/fastqc/raw" },
-            mode: params.publish_dir_mode,
-            pattern: '{*.html,*.zip}'
-        ]
+        ext.prefix = { "${meta.id}_raw" }
     }
-    withName: FASTQC_PREPROC_NO_SINGLETONS {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/fastqc/no_singletons" },
-            mode: params.publish_dir_mode,
-            pattern: '{*.html,*.zip}'
-        ]
+    withName: FASTQC_PREPROC {
+        ext.prefix = { "${meta.id}_host_filtered" }
     }
-    withName: FASTQC_PREPROC_WITH_SINGLETONS {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}/fastqc/with_singletons" },
-            mode: params.publish_dir_mode,
-            pattern: '{*.html,*.zip}'
-        ]
+    withName: FASTQC_PREPROC_SINGLETONS {
+        ext.prefix = { "${meta.id}_host_filtered_singletons" }
     }
     withName: NORMALIZE_COUNTS_GC {
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -136,7 +136,6 @@ process {
         ]
     }
     withName: FASTQC_RAW {
-        cpus = 2
         publishDir = [
             path: { "${params.outdir}/${meta.id}/fastqc/raw" },
             mode: params.publish_dir_mode,
@@ -144,7 +143,6 @@ process {
         ]
     }
     withName: FASTQC_PREPROC_NO_SINGLETONS {
-        cpus = 2
         publishDir = [
             path: { "${params.outdir}/${meta.id}/fastqc/no_singletons" },
             mode: params.publish_dir_mode,
@@ -152,7 +150,6 @@ process {
         ]
     }
     withName: FASTQC_PREPROC_WITH_SINGLETONS {
-        cpus = 2
         publishDir = [
             path: { "${params.outdir}/${meta.id}/fastqc/with_singletons" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -135,6 +135,30 @@ process {
              enabled: params.publish.logs]
         ]
     }
+    withName: FASTQC_RAW {
+        cpus = 2
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/fastqc/raw" },
+            mode: params.publish_dir_mode,
+            pattern: '{*.html,*.zip}'
+        ]
+    }
+    withName: FASTQC_PREPROC_NO_SINGLETONS {
+        cpus = 2
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/fastqc/no_singletons" },
+            mode: params.publish_dir_mode,
+            pattern: '{*.html,*.zip}'
+        ]
+    }
+    withName: FASTQC_PREPROC_WITH_SINGLETONS {
+        cpus = 2
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}/fastqc/with_singletons" },
+            mode: params.publish_dir_mode,
+            pattern: '{*.html,*.zip}'
+        ]
+    }
     withName: NORMALIZE_COUNTS_GC {
         publishDir = [
             path: { "${params.outdir}/${meta.id}/gene_counts_gc/" },

--- a/main.nf
+++ b/main.nf
@@ -115,17 +115,9 @@ workflow {
     hf_reads = BBMAP_FILTER_HOST(qf_reads, host_index.index).reads
     hf_singletons = BBMAP_FILTER_HOST_SINGLETONS(qf_singletons, host_index.index).reads
 
-    // QC toggles: raw QC is mandatory, preprocessed checkpoints remain optional
-    do_qc_preproc_no_singletons = !params.skip_qc_preproc_no_singletons
-    do_qc_preproc_with_singletons = !params.skip_qc_preproc_with_singletons
- 
-    if (do_qc_preproc_no_singletons) {
-        // Preprocessed QC without singletons (host-filtered paired/single reads)
+    if (!params.skip_qc_preprocessed) {
+        // QC on preprocessed reads
         fastqc_preproc_no_singletons = FASTQC_PREPROC_NO_SINGLETONS(hf_reads)
-    }
-
-    if (do_qc_preproc_with_singletons) {
-        // Preprocessed QC with singletons (all final reads)
         fastqc_preproc_with_singletons = FASTQC_PREPROC_WITH_SINGLETONS(hf_singletons)
     }
 

--- a/main.nf
+++ b/main.nf
@@ -20,6 +20,9 @@ include { MMSEQS_EASYCLUSTER as MMSEQS_EASYLINCLUST } from './modules/nf-core/mm
 include { CLASSIFY_4CAC } from './modules/local/4CAC/main'
 include { EGGNOGMAPPER as EGGNOGMAPPER_GC } from './modules/nf-core/eggnogmapper/main'
 include { EGGNOGMAPPER as EGGNOGMAPPER_SAMPLES } from './modules/nf-core/eggnogmapper/main'
+include { FASTQC as FASTQC_PREPROC_WITH_SINGLETONS } from './modules/nf-core/fastqc/main'
+include { FASTQC as FASTQC_PREPROC_NO_SINGLETONS } from './modules/nf-core/fastqc/main'
+include { FASTQC as FASTQC_RAW } from './modules/nf-core/fastqc/main'
 include { FILTER_SCAFFOLDS } from './modules/local/filter_scaffolds/main'
 include { FILTERSAM as FILTERSAM_GC } from './modules/local/filtersam/main'
 include { FILTERSAM as FILTERSAM_SAMPLES } from './modules/local/filtersam/main'
@@ -73,11 +76,11 @@ workflow {
     }
 
     samples = samples.branch {
-        already_preprocessed: 
+        already_preprocessed:
             params.resume_from_output && Files.isDirectory(Paths.get(outdir_abs, it[0].id, "preprocessed_reads"))
-        to_preprocess: 
+        to_preprocess:
             true
-        }
+    }
 
     ///////////////////
     // PRE-PROCESSING //
@@ -95,6 +98,9 @@ workflow {
     
     // Concat multi lane samples (if any)
     concatenated = CAT_FASTQ(to_preprocess.multi, false).reads.mix(to_preprocess.single)
+
+   // Run QC on the raw concatenated reads
+    fastqc_raw = FASTQC_RAW(concatenated)
     
     // We will skip preprocessing for samples which already have the preprocessed
     // folder in the ouput
@@ -155,8 +161,22 @@ workflow {
                 )
     }))
 
+    // QC toggles: raw QC is mandatory, preprocessed checkpoints remain optional
+    do_qc_preproc_no_singletons = !params.skip_qc_preproc_no_singletons
+    do_qc_preproc_with_singletons = !params.skip_qc_preproc_with_singletons
+ 
+    if (do_qc_preproc_no_singletons) {
+        // Preprocessed QC without singletons (host-filtered paired/single reads)
+        fastqc_preproc_no_singletons = FASTQC_PREPROC_NO_SINGLETONS(hf_reads)
+    }
+    
     // Make sure we have a single fastq file for all reads per sample
     reads = FORCE_SINGLE_FASTQ(preprocessed_samples, true).reads
+    
+    if (do_qc_preproc_with_singletons) {
+        // Preprocessed QC with singletons (all final reads)
+        fastqc_preproc_with_singletons = FASTQC_PREPROC_WITH_SINGLETONS(reads)
+    }
 
     /////////////////////////
     // Taxonomic Profiling //

--- a/main.nf
+++ b/main.nf
@@ -20,8 +20,8 @@ include { MMSEQS_EASYCLUSTER as MMSEQS_EASYLINCLUST } from './modules/nf-core/mm
 include { CLASSIFY_4CAC } from './modules/local/4CAC/main'
 include { EGGNOGMAPPER as EGGNOGMAPPER_GC } from './modules/nf-core/eggnogmapper/main'
 include { EGGNOGMAPPER as EGGNOGMAPPER_SAMPLES } from './modules/nf-core/eggnogmapper/main'
-include { FASTQC as FASTQC_PREPROC_WITH_SINGLETONS } from './modules/nf-core/fastqc/main'
-include { FASTQC as FASTQC_PREPROC_NO_SINGLETONS } from './modules/nf-core/fastqc/main'
+include { FASTQC as FASTQC_PREPROC } from './modules/nf-core/fastqc/main'
+include { FASTQC as FASTQC_PREPROC_SINGLETONS } from './modules/nf-core/fastqc/main'
 include { FASTQC as FASTQC_RAW } from './modules/nf-core/fastqc/main'
 include { FILTER_SCAFFOLDS } from './modules/local/filter_scaffolds/main'
 include { FILTERSAM as FILTERSAM_GC } from './modules/local/filtersam/main'
@@ -117,8 +117,8 @@ workflow {
 
     if (!params.skip_qc_preprocessed) {
         // QC on preprocessed reads
-        fastqc_preproc_no_singletons = FASTQC_PREPROC_NO_SINGLETONS(hf_reads)
-        fastqc_preproc_with_singletons = FASTQC_PREPROC_WITH_SINGLETONS(hf_singletons)
+        fastqc_preproc_no_singletons = FASTQC_PREPROC(hf_reads)
+        fastqc_preproc_with_singletons = FASTQC_PREPROC_SINGLETONS(hf_singletons)
     }
 
     // We only merge for paired-end reads

--- a/main.nf
+++ b/main.nf
@@ -115,6 +115,20 @@ workflow {
     hf_reads = BBMAP_FILTER_HOST(qf_reads, host_index.index).reads
     hf_singletons = BBMAP_FILTER_HOST_SINGLETONS(qf_singletons, host_index.index).reads
 
+    // QC toggles: raw QC is mandatory, preprocessed checkpoints remain optional
+    do_qc_preproc_no_singletons = !params.skip_qc_preproc_no_singletons
+    do_qc_preproc_with_singletons = !params.skip_qc_preproc_with_singletons
+ 
+    if (do_qc_preproc_no_singletons) {
+        // Preprocessed QC without singletons (host-filtered paired/single reads)
+        fastqc_preproc_no_singletons = FASTQC_PREPROC_NO_SINGLETONS(hf_reads)
+    }
+
+    if (do_qc_preproc_with_singletons) {
+        // Preprocessed QC with singletons (all final reads)
+        fastqc_preproc_with_singletons = FASTQC_PREPROC_WITH_SINGLETONS(hf_singletons)
+    }
+
     // We only merge for paired-end reads
     hf_reads_split = hf_reads.branch({
         single: it[0].single_end
@@ -161,23 +175,11 @@ workflow {
                 )
     }))
 
-    // QC toggles: raw QC is mandatory, preprocessed checkpoints remain optional
-    do_qc_preproc_no_singletons = !params.skip_qc_preproc_no_singletons
-    do_qc_preproc_with_singletons = !params.skip_qc_preproc_with_singletons
- 
-    if (do_qc_preproc_no_singletons) {
-        // Preprocessed QC without singletons (host-filtered paired/single reads)
-        fastqc_preproc_no_singletons = FASTQC_PREPROC_NO_SINGLETONS(hf_reads)
-    }
+
     
     // Make sure we have a single fastq file for all reads per sample
     reads = FORCE_SINGLE_FASTQ(preprocessed_samples, true).reads
     
-    if (do_qc_preproc_with_singletons) {
-        // Preprocessed QC with singletons (all final reads)
-        fastqc_preproc_with_singletons = FASTQC_PREPROC_WITH_SINGLETONS(reads)
-    }
-
     /////////////////////////
     // Taxonomic Profiling //
     /////////////////////////

--- a/modules.json
+++ b/modules.json
@@ -1,124 +1,99 @@
 {
-    "name": "",
-    "homePage": "",
-    "repos": {
-        "https://github.com/nf-core/modules.git": {
-            "modules": {
-                "nf-core": {
-                    "bbmap/align": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
-                        "patch": "modules/nf-core/bbmap/align/bbmap-align.diff"
-                    },
-                    "bbmap/bbduk": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
-                        "patch": "modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff"
-                    },
-                    "bbmap/bbmerge": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
-                        "patch": "modules/nf-core/bbmap/bbmerge/bbmap-bbmerge.diff"
-                    },
-                    "bbmap/index": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "bwa/index": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "bwa/mem": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
-                        "patch": "modules/nf-core/bwa/mem/bwa-mem.diff"
-                    },
-                    "cat/cat": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "cat/fastq": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "eggnogmapper": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "metaeuk/easypredict": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
-                        "patch": "modules/nf-core/metaeuk/easypredict/metaeuk-easypredict.diff"
-                    },
-                    "mmseqs/easycluster": {
-                        "branch": "master",
-                        "git_sha": "38697a933bef7041bb935c9b8374d9948ce6c794",
-                        "installed_by": [
-                            "modules"
-                        ],
-                        "patch": "modules/nf-core/mmseqs/easycluster/mmseqs-easycluster.diff"
-                    },
-                    "pigz/compress": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "prodigal": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "seqtk/subseq": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
-                    },
-                    "spades": {
-                        "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ],
-                        "patch": "modules/nf-core/spades/spades.diff"
-                    }
-                }
-            }
+  "name": "",
+  "homePage": "",
+  "repos": {
+    "https://github.com/nf-core/modules.git": {
+      "modules": {
+        "nf-core": {
+          "bbmap/align": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/bbmap/align/bbmap-align.diff"
+          },
+          "bbmap/bbduk": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/bbmap/bbduk/bbmap-bbduk.diff"
+          },
+          "bbmap/bbmerge": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/bbmap/bbmerge/bbmap-bbmerge.diff"
+          },
+          "bbmap/index": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "bwa/index": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "bwa/mem": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/bwa/mem/bwa-mem.diff"
+          },
+          "cat/cat": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "cat/fastq": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "eggnogmapper": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "fastqc": {
+            "branch": "master",
+            "git_sha": "3009f27c4e4b6e99da4eeebe82799e13924a4a1f",
+            "installed_by": ["modules"]
+          },
+          "metaeuk/easypredict": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/metaeuk/easypredict/metaeuk-easypredict.diff"
+          },
+          "mmseqs/easycluster": {
+            "branch": "master",
+            "git_sha": "38697a933bef7041bb935c9b8374d9948ce6c794",
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/mmseqs/easycluster/mmseqs-easycluster.diff"
+          },
+          "pigz/compress": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "prodigal": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "seqtk/subseq": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"]
+          },
+          "spades": {
+            "branch": "master",
+            "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+            "installed_by": ["modules"],
+            "patch": "modules/nf-core/spades/spades.diff"
+          }
         }
+      }
     }
+  }
 }

--- a/modules/nf-core/fastqc/environment.yml
+++ b/modules/nf-core/fastqc/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::fastqc=0.12.1

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -1,0 +1,54 @@
+process FASTQC {
+    tag "${meta.id}"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0' :
+        'biocontainers/fastqc:0.12.1--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta)             , path("*.html")                                                       , emit: html
+    tuple val(meta)             , path("*.zip")                                                        , emit: zip
+    tuple val("${task.process}"), val('fastqc'), eval('fastqc --version | sed "/FastQC v/!d; s/.*v//"'), emit: versions_fastqc, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args          = task.ext.args ?: ''
+    def prefix        = task.ext.prefix ?: "${meta.id}"
+    // Make list of old name and new name pairs to use for renaming in the bash while loop
+    def old_new_pairs = reads instanceof Path || reads.size() == 1 ? [[ reads, "${prefix}.${reads.extension}" ]] : reads.withIndex().collect { entry, index -> [ entry, "${prefix}_${index + 1}.${entry.extension}" ] }
+    def rename_to     = old_new_pairs*.join(' ').join(' ')
+    def renamed_files = old_new_pairs.collect{ _old_name, new_name -> new_name }.join(' ')
+
+    // The total amount of allocated RAM by FastQC is equal to the number of threads defined (--threads) time the amount of RAM defined (--memory)
+    // https://github.com/s-andrews/FastQC/blob/1faeea0412093224d7f6a07f777fad60a5650795/fastqc#L211-L222
+    // Dividing the task.memory by task.cpu allows to stick to requested amount of RAM in the label
+    def memory_in_mb = task.memory ? task.memory.toUnit('MB') / task.cpus : null
+    // FastQC memory value allowed range (100 - 10000)
+    def fastqc_memory = memory_in_mb > 10000 ? 10000 : (memory_in_mb < 100 ? 100 : memory_in_mb)
+
+    """
+    printf "%s %s\\n" ${rename_to} | while read old_name new_name; do
+        [ -f "\${new_name}" ] || ln -s \$old_name \$new_name
+    done
+
+    fastqc \\
+        ${args} \\
+        --threads ${task.cpus} \\
+        --memory ${fastqc_memory} \\
+        ${renamed_files}
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.html
+    touch ${prefix}.zip
+    """
+}

--- a/modules/nf-core/fastqc/meta.yml
+++ b/modules/nf-core/fastqc/meta.yml
@@ -1,0 +1,111 @@
+name: fastqc
+description: Run FastQC on sequenced reads
+keywords:
+  - quality control
+  - qc
+  - adapters
+  - fastq
+tools:
+  - fastqc:
+      description: |
+        FastQC gives general quality metrics about your reads.
+        It provides information about the quality score distribution
+        across your reads, the per base sequence content (%A/C/G/T).
+
+        You get information about adapter contamination and other
+        overrepresented sequences.
+      homepage: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/
+      documentation: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/
+      licence: ["GPL-2.0-only"]
+      identifier: biotools:fastqc
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+        ontologies: []
+output:
+  html:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.html":
+          type: file
+          description: FastQC report
+          pattern: "*_{fastqc.html}"
+          ontologies: []
+  zip:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.zip":
+          type: file
+          description: FastQC report archive
+          pattern: "*_{fastqc.zip}"
+          ontologies: []
+  versions_fastqc:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fastqc:
+          type: string
+          description: The tool name
+      - fastqc --version | sed "/FastQC v/!d; s/.*v//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - fastqc:
+          type: string
+          description: The tool name
+      - fastqc --version | sed "/FastQC v/!d; s/.*v//":
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@drpatelh"
+  - "@grst"
+  - "@ewels"
+  - "@FelixKrueger"
+maintainers:
+  - "@drpatelh"
+  - "@grst"
+  - "@ewels"
+  - "@FelixKrueger"
+containers:
+  conda:
+    linux_amd64:
+      lock_file: https://wave.seqera.io/v1alpha1/builds/bd-af7a5314d5015c29_1/condalock
+    linux_arm64:
+      lock_file: https://wave.seqera.io/v1alpha1/builds/bd-df99cb252670875a_2/condalock
+  docker:
+    linux_amd64:
+      build_id: bd-af7a5314d5015c29_1
+      name: community.wave.seqera.io/library/fastqc:0.12.1--af7a5314d5015c29
+      scanId: sc-a618548acbee5a8a_30
+    linux_arm64:
+      build_id: bd-df99cb252670875a_2
+      name: community.wave.seqera.io/library/fastqc:0.12.1--df99cb252670875a
+      scanId: sc-b5913ed5d42b22d2_18
+  singularity:
+    linux_amd64:
+      build_id: bd-104d26ddd9519960_1
+      name: oras://community.wave.seqera.io/library/fastqc:0.12.1--104d26ddd9519960
+      https: https://community.wave.seqera.io/v2/library/fastqc/blobs/sha256:e0c976cb2eca5fee72618a581537a4f8ea42fcae24c9b201e2e0f764fd28648a
+    linux_arm64:
+      build_id: bd-d56b505a93aef38a_1
+      name: oras://community.wave.seqera.io/library/fastqc:0.12.1--d56b505a93aef38a
+      https: https://community.wave.seqera.io/v2/library/fastqc/blobs/sha256:fd39534bf298698cbe3ee4d4a6f1e73330ec4bca44c38dd9a4d06cb5ea838017

--- a/modules/nf-core/fastqc/tests/main.nf.test
+++ b/modules/nf-core/fastqc/tests/main.nf.test
@@ -1,0 +1,309 @@
+nextflow_process {
+
+    name "Test Process FASTQC"
+    script "../main.nf"
+    process "FASTQC"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "fastqc"
+
+    test("sarscov2 single-end [fastq]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                // NOTE The report contains the date inside it, which means that the md5sum is stable per day, but not longer than that. So you can't md5sum it.
+                // looks like this: <div id="header_filename">Mon 2 Oct 2023<br/>test.gz</div>
+                // https://github.com/nf-core/modules/pull/3903#issuecomment-1743620039
+                { assert process.out.html[0][1] ==~ ".*/test_fastqc.html" },
+                { assert process.out.zip[0][1] ==~ ".*/test_fastqc.zip" },
+                { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert snapshot(sanitizeOutput(process.out).findAll { key, val -> key != 'html' && key != 'zip' }).match() }
+            )
+        }
+    }
+
+    test("sarscov2 paired-end [fastq]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.html[0][1][0] ==~ ".*/test_1_fastqc.html" },
+                { assert process.out.html[0][1][1] ==~ ".*/test_2_fastqc.html" },
+                { assert process.out.zip[0][1][0] ==~ ".*/test_1_fastqc.zip" },
+                { assert process.out.zip[0][1][1] ==~ ".*/test_2_fastqc.zip" },
+                { assert path(process.out.html[0][1][0]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert path(process.out.html[0][1][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert snapshot(sanitizeOutput(process.out).findAll { key, val -> key != 'html' && key != 'zip' }).match() }
+            )
+        }
+    }
+
+    test("sarscov2 interleaved [fastq]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true)
+                ])
+            """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.html[0][1] ==~ ".*/test_fastqc.html" },
+                { assert process.out.zip[0][1] ==~ ".*/test_fastqc.zip" },
+                { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert snapshot(sanitizeOutput(process.out).findAll { key, val -> key != 'html' && key != 'zip' }).match() }
+            )
+        }
+    }
+
+    test("sarscov2 paired-end [bam]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.html[0][1] ==~ ".*/test_fastqc.html" },
+                { assert process.out.zip[0][1] ==~ ".*/test_fastqc.zip" },
+                { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert snapshot(sanitizeOutput(process.out).findAll { key, val -> key != 'html' && key != 'zip' }).match() }
+            )
+        }
+    }
+
+    test("sarscov2 multiple [fastq]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_2.fastq.gz', checkIfExists: true) ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.html[0][1][0] ==~ ".*/test_1_fastqc.html" },
+                { assert process.out.html[0][1][1] ==~ ".*/test_2_fastqc.html" },
+                { assert process.out.html[0][1][2] ==~ ".*/test_3_fastqc.html" },
+                { assert process.out.html[0][1][3] ==~ ".*/test_4_fastqc.html" },
+                { assert process.out.zip[0][1][0] ==~ ".*/test_1_fastqc.zip" },
+                { assert process.out.zip[0][1][1] ==~ ".*/test_2_fastqc.zip" },
+                { assert process.out.zip[0][1][2] ==~ ".*/test_3_fastqc.zip" },
+                { assert process.out.zip[0][1][3] ==~ ".*/test_4_fastqc.zip" },
+                { assert path(process.out.html[0][1][0]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert path(process.out.html[0][1][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert path(process.out.html[0][1][2]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert path(process.out.html[0][1][3]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert snapshot(sanitizeOutput(process.out).findAll { key, val -> key != 'html' && key != 'zip' }).match() }
+            )
+        }
+    }
+
+    test("sarscov2 custom_prefix") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'mysample', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert process.out.html[0][1] ==~ ".*/mysample_fastqc.html" },
+                { assert process.out.zip[0][1] ==~ ".*/mysample_fastqc.zip" },
+                { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+                { assert snapshot(sanitizeOutput(process.out).findAll { key, val -> key != 'html' && key != 'zip' }).match() }
+            )
+        }
+    }
+
+    test("sarscov2 single-end [fastq] - stub") {
+
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id: 'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 paired-end [fastq] - stub") {
+
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true) ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 interleaved [fastq] - stub") {
+
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_interleaved.fastq.gz', checkIfExists: true)
+                ])
+            """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 paired-end [bam] - stub") {
+
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 multiple [fastq] - stub") {
+
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test', single_end: false], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_2.fastq.gz', checkIfExists: true) ]
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("sarscov2 custom_prefix - stub") {
+
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'mysample', single_end:true ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/fastqc/tests/main.nf.test.snap
+++ b/modules/nf-core/fastqc/tests/main.nf.test.snap
@@ -1,0 +1,476 @@
+{
+    "sarscov2 custom_prefix": {
+        "content": [
+            {
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:14.518503"
+    },
+    "sarscov2 single-end [fastq] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:19.309008"
+    },
+    "sarscov2 custom_prefix - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "mysample",
+                            "single_end": true
+                        },
+                        "mysample.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "mysample",
+                            "single_end": true
+                        },
+                        "mysample.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "mysample",
+                            "single_end": true
+                        },
+                        "mysample.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "mysample",
+                            "single_end": true
+                        },
+                        "mysample.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:44.94888"
+    },
+    "sarscov2 interleaved [fastq]": {
+        "content": [
+            {
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:38:45.168496"
+    },
+    "sarscov2 paired-end [bam]": {
+        "content": [
+            {
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:38:53.268919"
+    },
+    "sarscov2 multiple [fastq]": {
+        "content": [
+            {
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:05.050305"
+    },
+    "sarscov2 paired-end [fastq]": {
+        "content": [
+            {
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:38:37.2373"
+    },
+    "sarscov2 paired-end [fastq] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:24.450398"
+    },
+    "sarscov2 multiple [fastq] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:39.758762"
+    },
+    "sarscov2 single-end [fastq]": {
+        "content": [
+            {
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:38:29.555068"
+    },
+    "sarscov2 interleaved [fastq] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:29.193136"
+    },
+    "sarscov2 paired-end [bam] - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "html": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_fastqc": [
+                    [
+                        "FASTQC",
+                        "fastqc",
+                        "0.12.1"
+                    ]
+                ],
+                "zip": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.zip:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.0"
+        },
+        "timestamp": "2025-10-28T16:39:34.144919"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,9 +30,8 @@ params {
     skip_assembly           = false      // will also skip gene calling, counting and annotation
     skip_gene_catalog       = false  // do not make the gene catalog
     skip_per_sample         = true     // do not call, count and annotate genes per sample
-    skip_qc_preproc_no_singletons   = false     // skip preprocessed QC checkpoint without singletons (FASTQC)
-    skip_qc_preproc_with_singletons = false     // skip preprocessed QC checkpoint with singletons (FASTQC)
-
+    skip_qc_preprocessed    = false     // skip QC on preprocessed reads
+    
     // Resume options
     resume_from_output      = false
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,6 +30,8 @@ params {
     skip_assembly           = false      // will also skip gene calling, counting and annotation
     skip_gene_catalog       = false  // do not make the gene catalog
     skip_per_sample         = true     // do not call, count and annotate genes per sample
+    skip_qc_preproc_no_singletons   = false     // skip preprocessed QC checkpoint without singletons (FASTQC)
+    skip_qc_preproc_with_singletons = false     // skip preprocessed QC checkpoint with singletons (FASTQC)
 
     // Resume options
     resume_from_output      = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -158,6 +158,14 @@
         },
         "skip_motus": {
           "type": "boolean"
+        },
+        "skip_qc_preproc_no_singletons": {
+          "type": "boolean",
+          "default": false
+        },
+        "skip_qc_preproc_with_singletons": {
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -159,14 +159,10 @@
         "skip_motus": {
           "type": "boolean"
         },
-        "skip_qc_preproc_no_singletons": {
+        "skip_qc_preprocessed": {
           "type": "boolean",
           "default": false
         },
-        "skip_qc_preproc_with_singletons": {
-          "type": "boolean",
-          "default": false
-        }
       }
     }
   },


### PR DESCRIPTION
Adds FASTQC + MultiQC for raw and preprocessed reads.

- **Raw QC** will run on every sample that goes into the `to_preprocess` stream. 
- **Preprocessed reads QC** is set to run once for all host-filtered reads (including singletons), and once for host-filtered reads without singletons (phanta input). 
- Any or both of the preprocessed reads QC steps can be skipped using the flags `--skip_qc_preproc_no_singletons` and `skip_qc_preproc_with_singletons`.

Closes #46 